### PR TITLE
Remove unnecessary conditions and correct handlers order

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ strongswan_conns: {}
 Secrets are specified using `strongswan_secrets`. It is a list where each
 element might contain the following attributes:
 ```
-  left:       Optional - Any valid ID selector
-  right:      Optional - Any valid ID selector
-  type:       Optional (defaults to PSK) - any valid secret type
-  credential: Required - Connection's credentials
+  left:        Optional - Any valid ID selector
+  right:       Optional - Any valid ID selector
+  type:        Optional (defaults to PSK) - any valid secret type
+  credentials: Required - Connection's credentials
 ```
 
 ## Usage

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,12 +3,9 @@
 - name: ipsec reload
   command: >
     {{ strongswan_ipsec_bin }} reload
-  when: not (_strongswan_pkgs|changed)
 
 - name: ipsec secrets reload
   command: >
     {{ strongswan_ipsec_bin }} rereadsecrets
-  when: not (_strongswan_pkgs|changed)
-
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
 
-- name: ipsec reload
-  command: >
-    {{ strongswan_ipsec_bin }} reload
-
 - name: ipsec secrets reload
   command: >
     {{ strongswan_ipsec_bin }} rereadsecrets
+
+- name: ipsec reload
+  command: >
+    {{ strongswan_ipsec_bin }} reload
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Strongswan ipsec.conf
-  template:
-    src: etc/ipsec.conf.j2
-    dest: "{{ strongswan_config_file }}"
-    owner: "root"
-    group: "root"
-    mode: "0644"
-  notify: ipsec reload
-
 - name: Strongswan ipsec.secrets
   template:
     src: etc/ipsec.secrets.j2
@@ -17,5 +8,14 @@
     group: "root"
     mode: "0640"
   notify: ipsec secrets reload
+
+- name: Strongswan ipsec.conf
+  template:
+    src: etc/ipsec.conf.j2
+    dest: "{{ strongswan_config_file }}"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  notify: ipsec reload
 
 # vi:ts=2:sw=2:et:ft=yaml


### PR DESCRIPTION
This pull request is addressing several issues:
- during first role run on target, strongswan instance remains unconfigured due to presence of "when" conditions in handlers. Removing those resolves the issue also in subsequent runs - if there are package updates and configuration changes - reload of configuration/secrets should happen.
- when configuration changes are happening in both config and secret files, handler order was reloading configuration before updating secrets, which caused connections to fail. Reversing order - first secrets, later configuration updates is fixing the problem.
- There was missing "s" in credentials attribute on top of README.md